### PR TITLE
refactor: restrict seller role access and improve UI

### DIFF
--- a/src/components/layout/MainLayout/MainLayout.jsx
+++ b/src/components/layout/MainLayout/MainLayout.jsx
@@ -199,15 +199,17 @@ export default function MainLayout({ toggleTheme, themeMode, onLoginSuccess }) {
         label: "Ventas",
         dropdown: [
           { label: "Ventas", href: "/ventas/" },
-          { label: "Importar ventas", href: "/importar-ventas/", hidden: user.role === "seller" },
+          { label: "Importar ventas", href: "/importar-ventas/"},
         ],
+        hidden: user.role === "seller"
       },
       {
         label: "Caja",
         dropdown: [
-          { label: "Corte de caja", href: "/corte-caja/", hidden: user.role === "seller" },
+          { label: "Corte de caja", href: "/corte-caja/" },
           { label: "Movimientos en caja", href: "/movimientos-caja/" },
         ],
+        hidden: user.role === "seller"
       },
       { label: "Clientes", href: "/clientes/", hidden: user.role === "seller" },
       {
@@ -225,6 +227,7 @@ export default function MainLayout({ toggleTheme, themeMode, onLoginSuccess }) {
           { divider: true },
           { label: "Solicitudes de ajustes de stock", href: "/solicitudes-ajustes-stock/", hidden: user.role === "seller"},
         ],
+        hidden: user.role === "seller"
       },
 
       {
@@ -232,16 +235,19 @@ export default function MainLayout({ toggleTheme, themeMode, onLoginSuccess }) {
         dropdown: [
           { label: "Inventario a verificar", href: "/auditoria-inventario/" },
         ],
+        hidden: user.role === "seller",
       },
       
       {
         label: "Movimientos",
         dropdown: [
-          { label: "Distribuciones", href: "/distribuciones/" },
-          { label: "Traspasos", href: "/traspasos/" },
+          { label: "Distribuciones", href: "/distribuciones/", hidden: user.role === "seller" },
+          { label: "Traspasos", href: "/traspasos/", hidden: user.role === "seller" },
         ],
+        hidden: user.role === "seller",
       },
-      { label: "Historial de stock", href: "/historial-stock/" },
+      { label: "Traspasos", href: "/traspasos/", hidden: user.role !== "seller" },
+      { label: "Historial de stock", href: "/historial-stock/", hidden: user.role === "seller" },
     ],
     A: [
       { label: "Distribuir", href: "/distribuir/" },
@@ -273,7 +279,7 @@ export default function MainLayout({ toggleTheme, themeMode, onLoginSuccess }) {
           { label: "Inventario a verificar", href: "/auditoria-inventario/", hidden: user.role === "seller" },
         ],
       },
-      { label: "Historial de stock", href: "/historial-stock/" },
+      { label: "Historial de stock", href: "/historial-stock/", hidden: user.role === "seller" },
     ],
     G: [
       {
@@ -342,10 +348,14 @@ export default function MainLayout({ toggleTheme, themeMode, onLoginSuccess }) {
               <ArrowBackIcon />
             </IconButton>
           )}
-          <PendingMenu />
-          <DuplicateSalesMenu />
-          <StockRequestMenu />
-          <NotificationsMenu />
+                        <PendingMenu />
+          {user.role !== "seller" && (
+            <>
+              <DuplicateSalesMenu />
+              <StockRequestMenu />
+              <NotificationsMenu />
+            </>
+          )}
           <PageHelp />
           <IconButton color="inherit" onClick={toggleTheme} sx={{ mr: 1 }}>
             {themeMode === "dark" ? <Brightness7Icon /> : <Brightness4Icon />}
@@ -485,33 +495,37 @@ export default function MainLayout({ toggleTheme, themeMode, onLoginSuccess }) {
           })}
         </List>
         <Box sx={{ mt: "auto", p: 1 }}>
-          <ListItemButton
-            onClick={() => setShowUpdates(true)}
-            sx={{
-              borderRadius: 2, justifyContent: open ? "initial" : "center", mb: 1,
-              "&:hover": { backgroundColor: "rgba(167, 139, 250, 0.12)" },
-            }}
-          >
-            <ListItemIcon sx={{ color: "#a78bfa", minWidth: open ? 38 : 0, justifyContent: "center" }}>
-              <NewspaperIcon />
-            </ListItemIcon>
-            <ListItemText primary="Actualizaciones 2026" primaryTypographyProps={{ fontWeight: 600, fontSize: "0.8rem" }} sx={{ opacity: open ? 1 : 0 }} />
-          </ListItemButton>
-          <ListItemButton
-            component="a"
-            href={`https://api.whatsapp.com/send/?phone=${process.env.REACT_APP_WHATSAPP_NUMBER}&text=${encodeURIComponent(`Soporte SmartVenta\nTenant: ${user.tenant_name}\nTienda: ${user.store_name || "General"}`)}&type=phone_number&app_absent=0`}
-            target="_blank"
-            rel="noopener noreferrer"
-            sx={{
-              borderRadius: 2, justifyContent: open ? "initial" : "center",
-              "&:hover": { backgroundColor: "rgba(37, 211, 102, 0.12)" },
-            }}
-          >
-            <ListItemIcon sx={{ color: "#25D366", minWidth: open ? 38 : 0, justifyContent: "center" }}>
-              <WhatsAppIcon />
-            </ListItemIcon>
-            <ListItemText primary="Soporte" primaryTypographyProps={{ fontWeight: 600, fontSize: "0.8rem" }} sx={{ opacity: open ? 1 : 0 }} />
-          </ListItemButton>
+          {user.role !== "seller" && (
+            <>
+              <ListItemButton
+                onClick={() => setShowUpdates(true)}
+                sx={{
+                  borderRadius: 2, justifyContent: open ? "initial" : "center", mb: 1,
+                  "&:hover": { backgroundColor: "rgba(167, 139, 250, 0.12)" },
+                }}
+              >
+                <ListItemIcon sx={{ color: "#a78bfa", minWidth: open ? 38 : 0, justifyContent: "center" }}>
+                  <NewspaperIcon />
+                </ListItemIcon>
+                <ListItemText primary="Actualizaciones 2026" primaryTypographyProps={{ fontWeight: 600, fontSize: "0.8rem" }} sx={{ opacity: open ? 1 : 0 }} />
+              </ListItemButton>
+              <ListItemButton
+                component="a"
+                href={`https://api.whatsapp.com/send/?phone=${process.env.REACT_APP_WHATSAPP_NUMBER}&text=${encodeURIComponent(`Soporte SmartVenta\nTenant: ${user.tenant_name}\nTienda: ${user.store_name || "General"}`)}&type=phone_number&app_absent=0`}
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{
+                  borderRadius: 2, justifyContent: open ? "initial" : "center",
+                  "&:hover": { backgroundColor: "rgba(37, 211, 102, 0.12)" },
+                }}
+              >
+                <ListItemIcon sx={{ color: "#25D366", minWidth: open ? 38 : 0, justifyContent: "center" }}>
+                  <WhatsAppIcon />
+                </ListItemIcon>
+                <ListItemText primary="Soporte" primaryTypographyProps={{ fontWeight: 600, fontSize: "0.8rem" }} sx={{ opacity: open ? 1 : 0 }} />
+              </ListItemButton>
+            </>
+          )}
         </Box>
       </Drawer>
 

--- a/src/components/products/ProductList/ProductList.jsx
+++ b/src/components/products/ProductList/ProductList.jsx
@@ -35,7 +35,6 @@ const ProductList = () => {
   const [optionsLoaded, setOptionsLoaded] = useState(false);
   const [params, setParams] = useState({});
   const [selectedRows, setSelectedRows] = useState([]);
-  const [outOfStockPercentage, setOutOfStockPercentage] = useState(0);
   const productModal = useModal();
   const priceLogsModal = useModal();
 
@@ -54,8 +53,6 @@ const ProductList = () => {
     const response = await getProducts(params);
     const data = response.data;
     setProducts(data);
-    const outOfStock = data.filter((p) => p.stock === 0).length;
-    setOutOfStockPercentage((outOfStock / data.length) * 100);
     setLoading(false);
   };
 
@@ -200,13 +197,6 @@ const ProductList = () => {
                 </CustomButton>
               </CustomTooltip>
             </Grid>
-            {products.length > 0 && (
-              <Grid item xs={12} md={3}>
-                <Box sx={{ fontSize: '0.875rem' }}>
-                  {outOfStockPercentage.toFixed(0)}% de los productos está vacío
-                </Box>
-              </Grid>
-            )}
           </Grid>
 
           <DataTable

--- a/src/components/products/SearchProduct/SearchProduct.jsx
+++ b/src/components/products/SearchProduct/SearchProduct.jsx
@@ -1,6 +1,5 @@
 import { showSuccess, showError, showAlert } from "../../../utils/alerts";
 import { logger } from "../../../utils/logger";
-import Swal from "sweetalert2";
 import React, { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import SimpleTable from "../../ui/SimpleTable/SimpleTable";
@@ -62,7 +61,6 @@ const SearchProduct = ({ searchInputRef }) => {
   const [barcode, setBarcode] = useState("");
   const [isInputFocused, setIsInputFocused] = useState(false);
   const [keepListOpen, setKeepListOpen] = useState(false);
-  const [showStockAlert] = useState(() => localStorage.getItem('stockAlertDismissed') !== 'true');
   const [createProductsOnSale, setCreateProductsOnSale] = useState(false);
   const [stockVerificationSnackbar, setStockVerificationSnackbar] = useState({ open: false, productName: "", productCode: "" });
   
@@ -72,19 +70,6 @@ const SearchProduct = ({ searchInputRef }) => {
 
   // Usar hook de atajos de teclado
   useKeyboardShortcuts(inputRef, dispatch);
-
-  useEffect(() => {
-    if (showStockAlert) {
-      Swal.fire({
-        icon: 'info',
-        title: '¿Detectaste stock incorrecto?',
-        html: 'Ve a <a href="/inventario/" style="color: #04346b; font-weight: 600;">Inventario</a> y sigue las instrucciones para solicitar un ajuste',
-        confirmButtonText: 'Entendido',
-        confirmButtonColor: '#04346b',
-      });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     const checkCreateProductsOnSale = async () => {
@@ -195,7 +180,7 @@ const SearchProduct = ({ searchInputRef }) => {
       }} />
 
       <PageHeader title="Búsqueda de productos">
-        {stockVerificationSnackbar.open && (
+        {stockVerificationSnackbar.open && userData.role !== "seller" && (
           <Alert 
             severity="success" 
             variant="filled" 

--- a/src/components/products/StoreProductAuditList/StoreProductAuditList.jsx
+++ b/src/components/products/StoreProductAuditList/StoreProductAuditList.jsx
@@ -32,7 +32,7 @@ const StoreProductAuditList = () => {
   const [optionsLoaded, setOptionsLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
   const [params, setParams] = useState({ only_stock: true, requires_stock_verification: true });
-  const [outOfStockPercentage, setOutOfStockPercentage] = useState(0);
+  const [showAlert, setShowAlert] = useState(true);
 
   useEffect(() => {
     const fetchOptions = async () => {
@@ -52,8 +52,6 @@ const StoreProductAuditList = () => {
     const response = await getStoreProducts(params);
     const data = response.data;
     setStoreProducts(data);
-    const outOfStock = data.filter((p) => p.stock === 0).length;
-    setOutOfStockPercentage((outOfStock / data.length) * 100);
     setLoading(false);
   };
 
@@ -93,33 +91,29 @@ const StoreProductAuditList = () => {
         <Grid item xs={12} className="card">
           <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
             <h1>Inventario a verificar</h1>
-          </Stack>
-
-          <Alert 
-            severity="info" 
-            variant="filled" 
-            sx={{ mb: 2, py: 1.5, borderRadius: 2 }}
-            icon={<NotificationImportantIcon fontSize="inherit" />}
-          >
-            {user.role === "owner" ? (
-              <>
-                <strong>Mantente atento a las solicitudes de ajuste.</strong>{" "}
-                Revisa y aprueba las solicitudes de stock en{" "}
-                <Link to="/solicitudes-ajustes-stock/" style={{ color: "#04346b", fontWeight: 600 }}>
-                  Solicitudes de Ajuste
-                </Link>{" "}
-                para mantener el inventario actualizado.
-              </>
-            ) : (
-              <>
-                <strong>¿Ves un stock incorrecto?</strong> Si hay productos no registrados, regístralos. Si hay más productos registrados de los que realmente hay,{" "}
-                usa el icono <SendIcon sx={{ fontSize: 14, verticalAlign: "middle" }} /> en la columna Acciones para solicitar un ajuste de stock. 
-                El propietario revisará tu solicitud y la aprobará si es correcto. 
-                Se recomienda contactar al propietario para una pronta respuesta. 
-                Recuerda que tener el stock actualizado y corregido es un bien para todo el equipo.
-              </>
+            {showAlert && (
+            <Alert 
+              severity="info" 
+              variant="filled" 
+              sx={{ py: 0, borderRadius: 2, flex: 1, ml: 2 }}
+              icon={<NotificationImportantIcon fontSize="inherit" />}
+              onClose={() => setShowAlert(false)}
+            >
+              {user.role === "owner" ? (
+                <>
+                  <strong>Revisa y aprueba las solicitudes de stock en{" "}
+                  <Link to="/solicitudes-ajustes-stock/" style={{ color: "#04346b", fontWeight: 600 }}>
+                    Solicitudes de Ajuste
+                  </Link>.</strong>
+                </>
+              ) : (
+                <>
+                  <strong>¿Ves un stock incorrecto?</strong> Usa el icono <SendIcon sx={{ fontSize: 14, verticalAlign: "middle" }} /> para solicitar un ajuste.
+                </>
+              )}
+            </Alert>
             )}
-          </Alert>
+          </Stack>
 
           <Grid container spacing={2} sx={{ mb: 2 }}>
             <Grid item xs={12} md={3}>
@@ -167,13 +161,6 @@ const StoreProductAuditList = () => {
                 Descargar Inventario
               </CustomButton>
             </Grid>
-            {storeProducts.length > 0 && (
-              <Grid item xs={12} md={3}>
-                <Box sx={{ fontSize: '0.875rem', lineHeight: '40px' }}>
-                  {outOfStockPercentage.toFixed(0)}% de los productos está vacío
-                </Box>
-              </Grid>
-            )}
           </Grid>
 
           <DataTable
@@ -198,11 +185,13 @@ const StoreProductAuditList = () => {
                         </CustomButton>
                       </CustomTooltip>
                     )}
+                    {user.role !== "seller" && (
                     <CustomTooltip text="Movimientos de stock">
                       <CustomButton onClick={() => logsModal.open({ storeProduct: row, adjustStock: false })}>
                         <HistoryIcon />
                       </CustomButton>
                     </CustomTooltip>
+                    )}
                     {user.role !== "owner" && (
                       <CustomTooltip text="Solicitar ajuste de stock">
                         <CustomButton onClick={() => requestModal.open(row)}>

--- a/src/components/products/StoreProductList/StoreProductList.jsx
+++ b/src/components/products/StoreProductList/StoreProductList.jsx
@@ -32,7 +32,7 @@ const StoreProductList = () => {
   const [optionsLoaded, setOptionsLoaded] = useState(false);
   const [loading, setLoading] = useState(false);
   const [params, setParams] = useState({ only_stock: true });
-  const [outOfStockPercentage, setOutOfStockPercentage] = useState(0);
+  const [showAlert, setShowAlert] = useState(true);
 
   useEffect(() => {
     const fetchOptions = async () => {
@@ -49,8 +49,6 @@ const StoreProductList = () => {
     const response = await getStoreProducts(params);
     const data = response.data;
     setStoreProducts(data);
-    const outOfStock = data.filter((p) => p.stock === 0).length;
-    setOutOfStockPercentage((outOfStock / data.length) * 100);
     setLoading(false);
   };
 
@@ -90,33 +88,29 @@ const StoreProductList = () => {
         <Grid item xs={12} className="card">
           <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
             <h1>Inventario</h1>
-          </Stack>
-
-          <Alert 
-            severity="info" 
-            variant="filled" 
-            sx={{ mb: 2, py: 1.5, borderRadius: 2 }}
-            icon={<NotificationImportantIcon fontSize="inherit" />}
-          >
-            {user.role === "owner" ? (
-              <>
-                <strong>Mantente atento a las solicitudes de ajuste.</strong>{" "}
-                Revisa y aprueba las solicitudes de stock en{" "}
-                <Link to="/solicitudes-ajustes-stock/" style={{ color: "#04346b", fontWeight: 600 }}>
-                  Solicitudes de Ajuste
-                </Link>{" "}
-                para mantener el inventario actualizado.
-              </>
-            ) : (
-              <>
-                <strong>¿Ves un stock incorrecto?</strong> Si hay productos no registrados, regístralos. Si hay más productos registrados de los que realmente hay,{" "}
-                usa el icono <SendIcon sx={{ fontSize: 14, verticalAlign: "middle" }} /> en la columna Acciones para solicitar un ajuste de stock. 
-                El propietario revisará tu solicitud y la aprobará si es correcta. 
-                Se recomienda contactar al propietario para una pronta respuesta. 
-                Recuerda que tener el stock actualizado y corregido es un bien para todo el equipo.
-              </>
+            {showAlert && (
+            <Alert 
+              severity="info" 
+              variant="filled" 
+              sx={{ py: 0, borderRadius: 2, flex: 1, ml: 2 }}
+              icon={<NotificationImportantIcon fontSize="inherit" />}
+              onClose={() => setShowAlert(false)}
+            >
+              {user.role === "owner" ? (
+                <>
+                  <strong>Revisa y aprueba las solicitudes de stock en{" "}
+                  <Link to="/solicitudes-ajustes-stock/" style={{ color: "#04346b", fontWeight: 600 }}>
+                    Solicitudes de Ajuste
+                  </Link>.</strong>
+                </>
+              ) : (
+                <>
+                  <strong>¿Ves un stock incorrecto?</strong> Usa el icono <SendIcon sx={{ fontSize: 14, verticalAlign: "middle" }} /> para solicitar un ajuste.
+                </>
+              )}
+            </Alert>
             )}
-          </Alert>
+          </Stack>
 
           <Grid container spacing={2} sx={{ mb: 2 }}>
             <Grid item xs={12} md={3}>
@@ -159,17 +153,12 @@ const StoreProductList = () => {
                 Buscar
               </CustomButton>
             </Grid>
+            {user.role !== "seller" && (
             <Grid item xs={12} md={3}>
               <CustomButton fullWidth onClick={handleDownload} disabled={storeProducts.length === 0} startIcon={<DownloadIcon />}>
                 Descargar inventario
               </CustomButton>
             </Grid>
-            {storeProducts.length > 0 && (
-              <Grid item xs={12} md={3}>
-                <Box sx={{ fontSize: '0.875rem', lineHeight: '40px' }}>
-                  {outOfStockPercentage.toFixed(0)}% de los productos está vacío
-                </Box>
-              </Grid>
             )}
           </Grid>
 
@@ -195,11 +184,13 @@ const StoreProductList = () => {
                         </CustomButton>
                       </CustomTooltip>
                     )}
+                    {user.role !== "seller" && (
                     <CustomTooltip text="Movimientos de stock">
                       <CustomButton onClick={() => logsModal.open({ storeProduct: row, adjustStock: false })}>
                         <HistoryIcon />
                       </CustomButton>
                     </CustomTooltip>
+                    )}
                     {user.role !== "owner" && (
                       <CustomTooltip text="Solicitar ajuste de stock">
                         <CustomButton onClick={() => requestModal.open(row)}>

--- a/src/components/sales/CashSummary/CashSummary.jsx
+++ b/src/components/sales/CashSummary/CashSummary.jsx
@@ -5,10 +5,12 @@ import { getUserData } from "../../../api/utils";
 import { exportToExcel, getFormattedDate, formatTimeFromDate } from "../../../utils/utils";
 import { getCashSummary } from "../../../api/sales";
 import { getCashFlow } from "../../../api/cashflow";
+import { getDuplicateSales } from "../../../api/notifications";
+import { showAlert } from "../../../utils/alerts";
 import CashFlowModal from "../../finance/CashFlowModal/CashFlowModal";
 import { useModal } from "../../../hooks/useModal";
 import { CustomSpinner } from "../../ui/Spinner/Spinner";
-import { Grid, TextField, Box, Typography, Stack, Chip } from "@mui/material";
+import { Grid, TextField, Box, Typography, Stack } from "@mui/material";
 import DownloadIcon from "@mui/icons-material/Download";
 import PaymentIcon from "@mui/icons-material/Payment";
 import AccountBalanceWalletIcon from "@mui/icons-material/AccountBalanceWallet";
@@ -29,8 +31,6 @@ const CashSummary = () => {
   const [cashFlowSummary, setCashFlowSummary] = useState([]);
   const [totalSummary, setTotalSummary] = useState([]);
   const [loading, setLoading] = useState(false);
-
-  const isPartial = date === today;
 
   const processSummary = (data) => {
     setPaymentMethodsSummary(data.filter((c) => c.payment_method_data));
@@ -62,10 +62,24 @@ const CashSummary = () => {
     fetchSummary();
   }, [cashFlow, fetchSummary]);
 
+  useEffect(() => {
+    const fetchDuplicates = async () => {
+      try {
+        const { data } = await getDuplicateSales();
+        if (data && data.length > 0 && data[0].messages && data[0].messages.length > 0) {
+          const message = `${data[0].messages.join(", ")}\n\nPosiblemente no cuadren las cuentas por esas ventas duplicadas.`;
+          showAlert("Atención", message);
+        }
+      } catch (err) {
+        console.error("Error fetching duplicate sales:", err);
+      }
+    };
+    fetchDuplicates();
+  }, []);
+
   const handleExport = () => {
-    const dateFile = `${date}${isPartial ? " " + formatTimeFromDate() : ""}`;
-    const type = isPartial ? "parcial " : "total ";
-    exportToExcel(cashSummary, `Corte de caja ${type}${getUserData().store_name} ${dateFile}`, false);
+    const dateFile = `${date}`;
+    exportToExcel(cashSummary, `Corte de caja ${getUserData().store_name} ${dateFile}`, false);
   };
 
   const handleUpdateCashFlowList = (updated) => {
@@ -97,14 +111,7 @@ const CashSummary = () => {
 
       <Grid item xs={12} className="card">
         <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
-          <Stack direction="row" spacing={2} alignItems="center">
-            <Typography variant="h4" component="h1">Corte de caja</Typography>
-            <Chip
-              label={isPartial ? "Parcial" : "Total"}
-              color={isPartial ? "warning" : "success"}
-              size="small"
-            />
-          </Stack>
+          <Typography variant="h4" component="h1">Corte de caja</Typography>
           <CustomButton onClick={handleExport} startIcon={<DownloadIcon />}>
             Descargar corte
           </CustomButton>


### PR DESCRIPTION
- Hide audit, stock history, and movement menus for sellers
- Hide duplicate sales, pending movements, stock requests, and notifications icons for sellers
- Hide updates and WhatsApp support buttons for sellers
- Add "Traspasos" as direct menu item for sellers (not in dropdown)
- Remove stock modal alert on SearchProduct component
- Hide stock verification alert for sellers
- Remove outOfStockPercentage calculations and display
- Hide "Descargar inventario" and "Movimientos de stock" buttons for sellers
- Shorten seller inventory alert message
- Add duplicate sales alert on CashSummary page
- Remove isPartial logic from CashSummary
- Improve Alert styling with py: 0 and onClose handlers
- Move inventory alerts to header alongside titles