### PR TITLE
feat(subscriptions): pass full payment data from MP Brick to backend

### DIFF
--- a/src/components/tenant/MyCurrentPlan/MyCurrentPlan.jsx
+++ b/src/components/tenant/MyCurrentPlan/MyCurrentPlan.jsx
@@ -42,13 +42,16 @@ const MyCurrentPlan = () => {
     setTimeout(() => {
       createCardForm({
         amount: equivalent?.price || plan?.plan?.price,
-        onSubmit: async ({ token, email }) => {
+        onSubmit: async ({ token, email, payment_method_id, issuer_id, installments }) => {
           setSubmitting(true);
           try {
             const res = await createSubscription({
               plan_id: equivalent?.id || plan.plan.id,
               card_token: token,
               payer_email: email,
+              payment_method_id,
+              issuer_id,
+              installments,
             });
             if (res.status === 201 || res.status === 200) {
               unmountCardForm();

--- a/src/hooks/useMercadoPago.js
+++ b/src/hooks/useMercadoPago.js
@@ -28,7 +28,13 @@ export const useMercadoPago = () => {
       callbacks: {
         onReady: () => {},
         onSubmit: (cardFormData) => {
-          if (onSubmit) onSubmit({ token: cardFormData.token, email: cardFormData.payer.email });
+          if (onSubmit) onSubmit({
+            token: cardFormData.token,
+            email: cardFormData.payer.email,
+            payment_method_id: cardFormData.payment_method_id,
+            issuer_id: cardFormData.issuer_id,
+            installments: cardFormData.installments,
+          });
         },
         onError: (error) => {
           console.error('Brick error:', error);


### PR DESCRIPTION
Send payment_method_id, issuer_id and installments from the cardPayment Brick callback to the createSubscription endpoint, allowing the backend to use the correct values instead of hardcoding payment_method_id as 'credit_card'.