### PR TITLE
fix: ocultar columna Total en lista de ventas para vendedores

### DIFF
--- a/src/components/sales/SaleList/SaleList.jsx
+++ b/src/components/sales/SaleList/SaleList.jsx
@@ -242,7 +242,7 @@ const SaleList = () => {
               selector: (row) => <ProductsPopperButton row={row} productsModal={productsModal} />,
             },
             { name: "Número de productos", selector: (row) => row.products_sale?.reduce((sum, p) => sum + p.quantity, 0) || 0, width: 80 },
-            { name: "Total", selector: (row) => `$${row.total}`, width: 80 },
+            { name: "Total", selector: (row) => `$${row.total}`, width: 80, omit: user.role === "seller" },
             ...(params.reservation_in_progress === "true"
               ? [
                   { name: "Pagado", selector: (row) => "$" + row.paid, width: 80 },


### PR DESCRIPTION
El total sigue visible en el modal de cancelación/devolución para que puedan verificar la venta antes de procesar la operación.